### PR TITLE
#115 [Shortener] fix: guard EASYURL_SHOW_QRCODE user conf read (undefined property warning)

### DIFF
--- a/class/shortener.class.php
+++ b/class/shortener.class.php
@@ -522,7 +522,7 @@ class Shortener extends SaturneObject
         //$out .= '<td class="minwidth100"><i class="far fa-minus-square toggleObjectInfo" style="font-size: 1.5em; margin-right: 4px; vertical-align: middle;"></i>' . $langs->trans('UrlType') . '</td>';
         $out .= '<td class="short-url" style="vertical-align: middle;">' . $langs->trans('ShortUrl');
         if (!empty($user->id)) {
-            $out .= ($user->conf->EASYURL_SHOW_QRCODE ? img_picto($langs->trans('Enabled'), 'switch_on', 'class="show-qrcode marginleftonly pictoModule marginrightonly"') : img_picto($langs->trans('Disabled'), 'switch_off', 'class="show-qrcode marginleftonly pictoModule marginrightonly"'));
+            $out .= (!empty($user->conf->EASYURL_SHOW_QRCODE) ? img_picto($langs->trans('Enabled'), 'switch_on', 'class="show-qrcode marginleftonly pictoModule marginrightonly"') : img_picto($langs->trans('Disabled'), 'switch_off', 'class="show-qrcode marginleftonly pictoModule marginrightonly"'));
             $out .= $form->textwithpicto('', $langs->trans('ShowQRCode'));
         }
         $out .= '</td>';
@@ -541,7 +541,7 @@ class Shortener extends SaturneObject
             foreach ($shorteners as $shortener) {
                 $out .= '<tr>';
                 //$out .= '<td class="minwidth100">' . getDictionaryValue('c_shortener_url_type', 'label', $shortener->type) . '</td>';
-                $out .= '<td>' . ($user->conf->EASYURL_SHOW_QRCODE ? saturne_show_medias_linked('easyurl', $conf->easyurl->multidir_output[$conf->entity] . '/shortener/' . $shortener->ref . '/qrcode/', 'small', 1, 0, 0, 0, 80, 80, 0, 0, 1, 'shortener/'. $shortener->ref . '/qrcode/', $shortener, '', 0, 0) : dol_print_url($shortener->short_url, '_blank', 0, 1)) . '</td>';
+                $out .= '<td>' . (!empty($user->conf->EASYURL_SHOW_QRCODE) ? saturne_show_medias_linked('easyurl', $conf->easyurl->multidir_output[$conf->entity] . '/shortener/' . $shortener->ref . '/qrcode/', 'small', 1, 0, 0, 0, 80, 80, 0, 0, 1, 'shortener/'. $shortener->ref . '/qrcode/', $shortener, '', 0, 0) : dol_print_url($shortener->short_url, '_blank', 0, 1)) . '</td>';
                 $out .= '<td>' . $shortener->showOutputField($this->fields['original_url'], 'original_url', $shortener->original_url) . '</td>';
                 if (getDolGlobalInt('EASYURL_SHOW_API_INFOS')) {
                     $shortenerData = get_easy_url_link($object, 'all');


### PR DESCRIPTION
Closes #115

## Problem
Rendering the shortener object-info table on a linked element emits:

`Warning: Undefined property: stdClass::$EASYURL_SHOW_QRCODE in htdocs/custom/easyurl/class/shortener.class.php on line 525`

## Cause
`EASYURL_SHOW_QRCODE` is a per-user setting (`$user->conf`, from `llx_user_param`). It was read directly at lines 525 and 544 with no guard, so for any user who never toggled the QR-code switch the property is absent and PHP raises an undefined-property warning.

## Fix
Read the optional user param through `!empty()` (like `isset()`, it does not warn on a missing property) at both call sites. Behaviour is unchanged for users who have the switch on/off.

`php -l` passes.