### PR TITLE
#117 [Shortener] fix: display real YOURLS error on QRCode assignment

### DIFF
--- a/class/actions_easyurl.class.php
+++ b/class/actions_easyurl.class.php
@@ -254,7 +254,7 @@ class ActionsEasyurl
 
                         setEventMessages($langs->transnoentities('AssignQRCodeSuccess', $object->label, $langs->transnoentities($parameters['linkableElement']['langs']), $parameters['linkedObject']->{$parameters['linkableElement']['name_field']}), []);
                     } else {
-                        setEventMessages('AssignQRCodeErrors', [], 'errors');
+                        setEventMessages($langs->transnoentities('AssignQRCodeErrors') . (dol_strlen($object->error) > 0 ? ' : ' . $object->error : ''), [], 'errors');
                     }
                 } else {
                     setEventMessages('AssignQRCodeErrors', [], 'errors');

--- a/class/shortener.class.php
+++ b/class/shortener.class.php
@@ -522,7 +522,7 @@ class Shortener extends SaturneObject
         //$out .= '<td class="minwidth100"><i class="far fa-minus-square toggleObjectInfo" style="font-size: 1.5em; margin-right: 4px; vertical-align: middle;"></i>' . $langs->trans('UrlType') . '</td>';
         $out .= '<td class="short-url" style="vertical-align: middle;">' . $langs->trans('ShortUrl');
         if (!empty($user->id)) {
-            $out .= ($user->conf->EASYURL_SHOW_QRCODE ? img_picto($langs->trans('Enabled'), 'switch_on', 'class="show-qrcode marginleftonly pictoModule marginrightonly"') : img_picto($langs->trans('Disabled'), 'switch_off', 'class="show-qrcode marginleftonly pictoModule marginrightonly"'));
+            $out .= (getDolUserInt('EASYURL_SHOW_QRCODE') ? img_picto($langs->trans('Enabled'), 'switch_on', 'class="show-qrcode marginleftonly pictoModule marginrightonly"') : img_picto($langs->trans('Disabled'), 'switch_off', 'class="show-qrcode marginleftonly pictoModule marginrightonly"'));
             $out .= $form->textwithpicto('', $langs->trans('ShowQRCode'));
         }
         $out .= '</td>';
@@ -541,7 +541,7 @@ class Shortener extends SaturneObject
             foreach ($shorteners as $shortener) {
                 $out .= '<tr>';
                 //$out .= '<td class="minwidth100">' . getDictionaryValue('c_shortener_url_type', 'label', $shortener->type) . '</td>';
-                $out .= '<td>' . ($user->conf->EASYURL_SHOW_QRCODE ? saturne_show_medias_linked('easyurl', $conf->easyurl->multidir_output[$conf->entity] . '/shortener/' . $shortener->ref . '/qrcode/', 'small', 1, 0, 0, 0, 80, 80, 0, 0, 1, 'shortener/'. $shortener->ref . '/qrcode/', $shortener, '', 0, 0) : dol_print_url($shortener->short_url, '_blank', 0, 1)) . '</td>';
+                $out .= '<td>' . (getDolUserInt('EASYURL_SHOW_QRCODE') ? saturne_show_medias_linked('easyurl', $conf->easyurl->multidir_output[$conf->entity] . '/shortener/' . $shortener->ref . '/qrcode/', 'small', 1, 0, 0, 0, 80, 80, 0, 0, 1, 'shortener/'. $shortener->ref . '/qrcode/', $shortener, '', 0, 0) : dol_print_url($shortener->short_url, '_blank', 0, 1)) . '</td>';
                 $out .= '<td>' . $shortener->showOutputField($this->fields['original_url'], 'original_url', $shortener->original_url) . '</td>';
                 if (getDolGlobalInt('EASYURL_SHOW_API_INFOS')) {
                     $shortenerData = get_easy_url_link($object, 'all');

--- a/lib/easyurl_function.lib.php
+++ b/lib/easyurl_function.lib.php
@@ -203,10 +203,36 @@ function update_easy_url_link(CommonObject $object): int
     $ch = init_easy_url_curl($curlPostFields);
 
     // Fetch and return content
-    $data = curl_exec($ch);
+    $data    = curl_exec($ch);
+    $curlErr = curl_error($ch);
     curl_close($ch);
 
     // Do something with the result
     $data = json_decode($data);
-    return $data->statusCode == 200 ? 1 : 0;
+    if (is_object($data) && $data->statusCode == 200) {
+        return 1;
+    }
+
+    // Propagate the real error to the caller so it can be displayed to the user
+    $statusCode = (is_object($data) && isset($data->statusCode)) ? $data->statusCode : '';
+    $apiMessage = '';
+    if (is_object($data)) {
+        foreach ((array) $data as $key => $value) {
+            if (trim($key) === 'simple' && dol_strlen($value) > 0) { // YOURLS renvoie une clé "simple " (avec un espace) contenant le message lisible
+                $apiMessage = $value;
+                break;
+            }
+        }
+        if (empty($apiMessage) && !empty($data->message)) {
+            $apiMessage = $data->message;
+        }
+    }
+    if (empty($apiMessage)) {
+        $apiMessage = (dol_strlen($curlErr) > 0 ? $curlErr : 'No response from URL shortener API');
+    }
+
+    $object->error    = (dol_strlen($statusCode) > 0 ? '[' . $statusCode . '] ' : '') . $apiMessage;
+    $object->errors[] = $object->error;
+
+    return 0;
 }


### PR DESCRIPTION
## Changements
- `update_easy_url_link()` récupère désormais le message d'erreur réel de l'API YOURLS (clé `simple`, sinon `message`, sinon l'erreur cURL) ainsi que le code statut, et les place dans `$object->error`.
- L'action `assign_qrcode` affiche le message générique « Erreur : affectation du QRCode » **+** la vraie erreur (ex. `[404] Error: keyword accesscopac-eu2603-0001 not found`) au lieu du message opaque.
- Garde `is_object()` ajouté avant la lecture de `statusCode` pour éviter un warning quand la réponse cURL est nulle.
- Correction d'un `Warning: Undefined property: stdClass::$EASYURL_SHOW_QRCODE` (PHP 8) dans `displayObjectDetails()` : accès direct `$user->conf->EASYURL_SHOW_QRCODE` remplacé par `getDolUserInt('EASYURL_SHOW_QRCODE')` (lignes 525 et 544), sûr quand la préférence utilisateur n'a jamais été enregistrée.

## Fichiers modifiés
- `lib/easyurl_function.lib.php`
- `class/actions_easyurl.class.php`
- `class/shortener.class.php`

## Issue
Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
